### PR TITLE
Updates to be compatible with Terraform 0.12+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea/
+drop/
+go_build_main_go

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Terraform-Demo
 Terraform-Demo
+
+
+#Watch out that app service name is unique.
+
+Error: The name "terraform-app-service" used for the App Service 
+needs to be globally unique and isn't available: 
+Hostname 'terraform-app-service' already exists. Please select a different name.
+

--- a/app-service-and-sql-database-var/main.tf
+++ b/app-service-and-sql-database-var/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_app_service_plan" "ASP-TerraForm" {
   }
 }
 
-resource "azurerm_app_service" "AP-Terraform" {
+resource "azurerm_app_service" "AS-Terraform" {
   name                = "app-service-terraform"
   location            = azurerm_resource_group.RG-Terraform.location
   resource_group_name = azurerm_resource_group.RG-Terraform.name

--- a/app-service-and-sql-database-var/main.tf
+++ b/app-service-and-sql-database-var/main.tf
@@ -1,12 +1,12 @@
-resource "azurerm_resource_group" "test" {
-  name     = "var.resource-group-name"
-  location = "var.location"
+resource "azurerm_resource_group" "RG-Terraform" {
+  name     = "terraform-resource-group"
+  location = "West Europe"
 }
 
-resource "azurerm_app_service_plan" "test" {
-  name                = "example-appserviceplan"
-  location            = "azurerm_resource_group.test.location}"
-  resource_group_name = azurerm_resource_group.test.name
+resource "azurerm_app_service_plan" "ASP-TerraForm" {
+  name                = "terraform-appserviceplan"
+  location            = azurerm_resource_group.RG-Terraform.location
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
 
   sku {
     tier = "Standard"
@@ -14,11 +14,11 @@ resource "azurerm_app_service_plan" "test" {
   }
 }
 
-resource "azurerm_app_service" "test" {
-  name                = var.app-service-name
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
+resource "azurerm_app_service" "AP-Terraform" {
+  name                = "app-service-terraform"
+  location            = azurerm_resource_group.RG-Terraform.location
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
+  app_service_plan_id = azurerm_app_service_plan.ASP-TerraForm.id
 
   site_config {
     dotnet_framework_version = "v4.0"
@@ -38,8 +38,8 @@ resource "azurerm_app_service" "test" {
 
 resource "azurerm_sql_server" "test" {
   name                         = "terraform-sqlserver"
-  resource_group_name          = azurerm_resource_group.test.name
-  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.RG-Terraform.name
+  location                     = azurerm_resource_group.RG-Terraform.location
   version                      = "12.0"
   administrator_login          = "houssem"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"
@@ -47,8 +47,8 @@ resource "azurerm_sql_server" "test" {
 
 resource "azurerm_sql_database" "test" {
   name                = "terraform-sqldatabase"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
+  location            = azurerm_resource_group.RG-Terraform.location
   server_name         = azurerm_sql_server.test.name
 
   tags = {

--- a/app-service-and-sql-database-var/main.tf
+++ b/app-service-and-sql-database-var/main.tf
@@ -1,12 +1,12 @@
 resource "azurerm_resource_group" "test" {
-  name     = "${var.resource-group-name}"
-  location = "${var.location}"
+  name     = "var.resource-group-name"
+  location = "var.location"
 }
 
 resource "azurerm_app_service_plan" "test" {
   name                = "example-appserviceplan"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "azurerm_resource_group.test.location}"
+  resource_group_name = azurerm_resource_group.test.name
 
   sku {
     tier = "Standard"
@@ -15,10 +15,10 @@ resource "azurerm_app_service_plan" "test" {
 }
 
 resource "azurerm_app_service" "test" {
-  name                = "${var.app-service-name}"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  name                = var.app-service-name
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
 
   site_config {
     dotnet_framework_version = "v4.0"
@@ -38,8 +38,8 @@ resource "azurerm_app_service" "test" {
 
 resource "azurerm_sql_server" "test" {
   name                         = "terraform-sqlserver"
-  resource_group_name          = "${azurerm_resource_group.test.name}"
-  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
   version                      = "12.0"
   administrator_login          = "houssem"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"
@@ -47,9 +47,9 @@ resource "azurerm_sql_server" "test" {
 
 resource "azurerm_sql_database" "test" {
   name                = "terraform-sqldatabase"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-  server_name         = "${azurerm_sql_server.test.name}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  server_name         = azurerm_sql_server.test.name
 
   tags = {
     environment = "production"

--- a/app-service-and-sql-database-var/variables.tf
+++ b/app-service-and-sql-database-var/variables.tf
@@ -1,14 +1,14 @@
 variable "resource-group-name" {
-  default = "terraform-resource-group"
+  default     = "terraform-resource-group"
   description = "The prefix used for all resources in this example"
 }
 
 variable "app-service-name" {
-  default = "terraform-app-service"
+  default     = "terraform-app-service"
   description = "The name of the Web App"
 }
 
 variable "location" {
-  default = "West Europe"
+  default     = "West Europe"
   description = "The Azure location where all resources in this example should be created"
 }

--- a/app-service-and-sql-database/main.tf
+++ b/app-service-and-sql-database/main.tf
@@ -5,8 +5,8 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_app_service_plan" "test" {
   name                = "example-appserviceplan"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
   sku {
     tier = "Standard"
@@ -16,9 +16,9 @@ resource "azurerm_app_service_plan" "test" {
 
 resource "azurerm_app_service" "test" {
   name                = "terraform-app-service"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
 
   site_config {
     dotnet_framework_version = "v4.0"
@@ -38,8 +38,8 @@ resource "azurerm_app_service" "test" {
 
 resource "azurerm_sql_server" "test" {
   name                         = "terraform-sqlserver"
-  resource_group_name          = "${azurerm_resource_group.test.name}"
-  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
   version                      = "12.0"
   administrator_login          = "houssem"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"
@@ -47,9 +47,9 @@ resource "azurerm_sql_server" "test" {
 
 resource "azurerm_sql_database" "test" {
   name                = "terraform-sqldatabase"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-  server_name         = "${azurerm_sql_server.test.name}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  server_name         = azurerm_sql_server.test.name
 
   tags = {
     environment = "production"

--- a/app-service-and-sql-database/main.tf
+++ b/app-service-and-sql-database/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_app_service_plan" "ASP-TerraForm" {
   }
 }
 
-resource "azurerm_app_service" "AP-Terraform" {
+resource "azurerm_app_service" "AS-Terraform" {
   name                = "app-service-terraform"
   location            = azurerm_resource_group.RG-Terraform.location
   resource_group_name = azurerm_resource_group.RG-Terraform.name

--- a/app-service-and-sql-database/main.tf
+++ b/app-service-and-sql-database/main.tf
@@ -1,12 +1,12 @@
-resource "azurerm_resource_group" "test" {
-  name     = "example-resources"
+resource "azurerm_resource_group" "RG-Terraform" {
+  name     = "terraform-resource-group"
   location = "West Europe"
 }
 
-resource "azurerm_app_service_plan" "test" {
-  name                = "example-appserviceplan"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+resource "azurerm_app_service_plan" "ASP-TerraForm" {
+  name                = "terraform-appserviceplan"
+  location            = azurerm_resource_group.RG-Terraform.location
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
 
   sku {
     tier = "Standard"
@@ -14,11 +14,11 @@ resource "azurerm_app_service_plan" "test" {
   }
 }
 
-resource "azurerm_app_service" "test" {
-  name                = "terraform-app-service"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
+resource "azurerm_app_service" "AP-Terraform" {
+  name                = "app-service-terraform"
+  location            = azurerm_resource_group.RG-Terraform.location
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
+  app_service_plan_id = azurerm_app_service_plan.ASP-TerraForm.id
 
   site_config {
     dotnet_framework_version = "v4.0"
@@ -32,24 +32,24 @@ resource "azurerm_app_service" "test" {
   connection_string {
     name  = "Database"
     type  = "SQLServer"
-    value = "Server=tcp:${azurerm_sql_server.test.fully_qualified_domain_name} Database=${azurerm_sql_database.test.name};User ID=${azurerm_sql_server.test.administrator_login};Password=${azurerm_sql_server.test.administrator_login_password};Trusted_Connection=False;Encrypt=True;"
+    value = "Server=tcp:${azurerm_sql_server.terraform-sqlserver.fully_qualified_domain_name} Database=${azurerm_sql_database.terraform-sqldatabase.name};User ID=${azurerm_sql_server.terraform-sqlserver.administrator_login};Password=${azurerm_sql_server.terraform-sqlserver.administrator_login_password};Trusted_Connection=False;Encrypt=True;"
   }
 }
 
-resource "azurerm_sql_server" "test" {
+resource "azurerm_sql_server" "terraform-sqlserver" {
   name                         = "terraform-sqlserver"
-  resource_group_name          = azurerm_resource_group.test.name
-  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.RG-Terraform.name
+  location                     = azurerm_resource_group.RG-Terraform.location
   version                      = "12.0"
   administrator_login          = "houssem"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"
 }
 
-resource "azurerm_sql_database" "test" {
+resource "azurerm_sql_database" "terraform-sqldatabase" {
   name                = "terraform-sqldatabase"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  server_name         = azurerm_sql_server.test.name
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
+  location            = azurerm_resource_group.RG-Terraform.location
+  server_name         = azurerm_sql_server.terraform-sqlserver.name
 
   tags = {
     environment = "production"

--- a/app-service-variables/main.tf
+++ b/app-service-variables/main.tf
@@ -1,12 +1,12 @@
 resource "azurerm_resource_group" "test" {
-  name     = "${var.resource-group-name}"
-  location = "${var.location}"
+  name     = var.resource-group-name
+  location = var.location
 }
 
 resource "azurerm_app_service_plan" "test" {
   name                = "terraform-appserviceplan"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
   sku {
     tier = "Standard"
@@ -15,10 +15,10 @@ resource "azurerm_app_service_plan" "test" {
 }
 
 resource "azurerm_app_service" "test" {
-  name                = "${var.app-service-name}"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  name                = var.app-service-name
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
 
   site_config {
     dotnet_framework_version = "v4.0"

--- a/app-service-variables/outputs.tf
+++ b/app-service-variables/outputs.tf
@@ -1,5 +1,5 @@
 output "app_service_name" {
-  value = "${azurerm_app_service.test.name}"
+  value = azurerm_app_service.test.name
 }
 
 output "app_service_default_hostname" {

--- a/app-service-variables/variables.tf
+++ b/app-service-variables/variables.tf
@@ -1,14 +1,14 @@
 variable "resource-group-name" {
-  default = "terraform-resource-group"
+  default     = "terraform-resource-group"
   description = "The prefix used for all resources in this example"
 }
 
 variable "location" {
-  default = "West Europe"
+  default     = "West Europe"
   description = "The Azure location where all resources in this example should be created"
 }
 
 variable "app-service-name" {
-  default = "terraform-app-service"
+  default     = "terraform-app-service"
   description = "The name of the app service"
 }

--- a/app-service/backend.tf
+++ b/app-service/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "azurerm" {
+  }
+}

--- a/app-service/main.tf
+++ b/app-service/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_app_service_plan" "ASP-TerraForm" {
   }
 }
 
-resource "azurerm_app_service" "AP-Terraform" {
+resource "azurerm_app_service" "AS-Terraform" {
   name                = "app-service-terraform"
   location            = azurerm_resource_group.RG-Terraform.location
   resource_group_name = azurerm_resource_group.RG-Terraform.name

--- a/app-service/main.tf
+++ b/app-service/main.tf
@@ -5,8 +5,8 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_app_service_plan" "test" {
   name                = "terraform-appserviceplan"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
   sku {
     tier = "Standard"
@@ -16,9 +16,9 @@ resource "azurerm_app_service_plan" "test" {
 
 resource "azurerm_app_service" "test" {
   name                = "terraform-app-service"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
 
   site_config {
     dotnet_framework_version = "v4.0"

--- a/app-service/main.tf
+++ b/app-service/main.tf
@@ -1,12 +1,12 @@
-resource "azurerm_resource_group" "test" {
+resource "azurerm_resource_group" "RG-Terraform" {
   name     = "terraform-resource-group"
   location = "West Europe"
 }
 
-resource "azurerm_app_service_plan" "test" {
+resource "azurerm_app_service_plan" "ASP-TerraForm" {
   name                = "terraform-appserviceplan"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.RG-Terraform.location
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
 
   sku {
     tier = "Standard"
@@ -14,11 +14,11 @@ resource "azurerm_app_service_plan" "test" {
   }
 }
 
-resource "azurerm_app_service" "test" {
-  name                = "terraform-app-service"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
+resource "azurerm_app_service" "AP-Terraform" {
+  name                = "app-service-terraform"
+  location            = azurerm_resource_group.RG-Terraform.location
+  resource_group_name = azurerm_resource_group.RG-Terraform.name
+  app_service_plan_id = azurerm_app_service_plan.ASP-TerraForm.id
 
   site_config {
     dotnet_framework_version = "v4.0"


### PR DESCRIPTION
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.